### PR TITLE
Address warning that username is deprecated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This package is still under development and isn't too stable yet, but can be ins
 
 
 ```r
-devtools::install_github('ggthemr', 'cttobin')
+devtools::install_github('cttobin/ggthemr')
 ```
 
 Usage


### PR DESCRIPTION
Hi @cttobin !

Got the following when installing:
```
Warning message:
Username parameter is deprecated. Please use cttobin/ggthemr
```