### PR TITLE
Updated options to be reset in `gghtemr_reset`

### DIFF
--- a/R/ggthemr_reset.R
+++ b/R/ggthemr_reset.R
@@ -8,9 +8,9 @@ ggthemr_reset <- function () {
     
     # resetting scales
     options('ggplot2.discrete.fill' = NULL)
-    options('ggplot2.discrete.color' = NULL)
+    options('ggplot2.discrete.colour' = NULL)
     options('ggplot2.continuous.fill' = NULL)
-    options('ggplot2.continuous.color' = NULL)
+    options('ggplot2.continuous.colour' = NULL)
     
     # resetting geoms
     current_theme_info <- get_themr()


### PR DESCRIPTION
This should fix #55 as the reset didn't reset the UK spelling for the options (see #52)