### PR TITLE
Added options for ggplot2.ordinal.{fill,colour}

### DIFF
--- a/R/ggthemr.R
+++ b/R/ggthemr.R
@@ -53,8 +53,15 @@ ggthemr <- function(palette     = 'dust',
   colours <- palette$swatch[-1]
   options('ggplot2.discrete.fill' = function(...) discrete_scale('fill', 'ggthemr', discrete_colours(colours), ...))
   options('ggplot2.discrete.colour' = function(...) discrete_scale('colour', 'ggthemr', discrete_colours(colours), ...))
+
+  options('ggplot2.ordinal.fill' = function(...) discrete_scale('fill', 'ggthemr', discrete_colours(colours), ...))
+  options('ggplot2.ordinal.colour' = function(...) discrete_scale('colour', 'ggthemr', discrete_colours(colours), ...))
+
+                                                                     
+  
   options('ggplot2.continuous.fill' = function(...) continuous_scale('fill', 'ggthemr',
-                                                                     seq_gradient_pal(palette$gradient[['low']], palette$gradient[['high']], 'Lab'),
+
+seq_gradient_pal(palette$gradient[['low']], palette$gradient[['high']], 'Lab'),
                                                                      guide = 'colourbar', ...))
   options('ggplot2.continuous.colour' = function(...) continuous_scale('colour', 'ggthemr',
                                                                       seq_gradient_pal(palette$gradient[['low']], palette$gradient[['high']], 'Lab'),

--- a/R/ggthemr_reset.R
+++ b/R/ggthemr_reset.R
@@ -11,6 +11,8 @@ ggthemr_reset <- function () {
     options('ggplot2.discrete.color' = NULL)
     options('ggplot2.continuous.fill' = NULL)
     options('ggplot2.continuous.color' = NULL)
+    options('ggplot2.ordinal.colour' = NULL)
+    options('ggplot2.ordinal.fill' = NULL)
     
     # resetting geoms
     current_theme_info <- get_themr()


### PR DESCRIPTION
This should make ggplot respect the current ggthemr theme palette / swatch and not default to viridis for ordinal factors.

Also resolves the issue noted in the `.Rmd` update in #57 about the histograms.